### PR TITLE
feat: make Fastify bodyLimit configurable via BODY_LIMIT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ S3_REGION=
 S3_SESSION_TOKEN=
 S3_FORCE_PATH_STYLE=
 S3_ENDPOINT=
+
+# optional: maximum request body size in bytes for artifact uploads.
+# Applied to the underlying Fastify server. Defaults to 1073741824 (1 GiB).
+BODY_LIMIT=
 ```
 
 ## Configuring Turborepo to use your cache server

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -43,7 +43,40 @@ describe("Configuration", () => {
           provider: validConfigurationLocal.STORAGE_PROVIDER,
           basePath: validConfigurationLocal.LOCAL_STORAGE_PATH,
         },
+        server: {
+          bodyLimit: 1024 * 1024 * 1024,
+        },
       });
+    });
+  });
+
+  describe("BODY_LIMIT", () => {
+    it("defaults to 1 GiB when unset", () => {
+      const configuration = validate(validConfigurationLocal);
+      expect(configuration.server.bodyLimit).toBe(1024 * 1024 * 1024);
+    });
+
+    it("accepts a custom positive integer (bytes)", () => {
+      const configuration = validate({
+        ...validConfigurationLocal,
+        BODY_LIMIT: "2147483648",
+      });
+      expect(configuration.server.bodyLimit).toBe(2147483648);
+    });
+
+    it("rejects non-numeric values", () => {
+      expect(() =>
+        validate({ ...validConfigurationLocal, BODY_LIMIT: "1gb" }),
+      ).toThrow();
+    });
+
+    it("rejects zero and negatives", () => {
+      expect(() =>
+        validate({ ...validConfigurationLocal, BODY_LIMIT: "0" }),
+      ).toThrow();
+      expect(() =>
+        validate({ ...validConfigurationLocal, BODY_LIMIT: "-1" }),
+      ).toThrow();
     });
   });
 
@@ -77,6 +110,9 @@ describe("Configuration", () => {
           region: validConfigurationS3.S3_REGION,
           endpoint: validConfigurationS3.S3_ENDPOINT,
           forcePathStyle: validConfigurationS3.S3_FORCE_PATH_STYLE === "true",
+        },
+        server: {
+          bodyLimit: 1024 * 1024 * 1024,
         },
       });
     });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 const splitComma = (s: string) => s.split(",");
 
+const DEFAULT_BODY_LIMIT = 1024 * 1024 * 1024;
+
 const configurationSchema = z
   .intersection(
     z.object({
@@ -9,6 +11,21 @@ const configurationSchema = z
         .string()
         .transform(splitComma)
         .pipe(z.string().min(1).array()),
+      BODY_LIMIT: z
+        .string()
+        .optional()
+        .default(String(DEFAULT_BODY_LIMIT))
+        .transform((v, ctx) => {
+          const n = Number(v);
+          if (!Number.isInteger(n) || n <= 0) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "BODY_LIMIT must be a positive integer (bytes)",
+            });
+            return z.NEVER;
+          }
+          return n;
+        }),
     }),
     z.union([
       z.object({
@@ -54,6 +71,7 @@ const configurationSchema = z
     return {
       storage,
       auth: { tokens: data.AUTH_TOKENS },
+      server: { bodyLimit: data.BODY_LIMIT },
     };
   });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,11 +6,13 @@ import {
   NestFastifyApplication,
 } from "@nestjs/platform-fastify";
 import { AppModule } from "./app.module";
+import { validate } from "./config/configuration";
 
 async function bootstrap() {
+  const { server } = validate(process.env);
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
-    new FastifyAdapter({ bodyLimit: 1024 * 1024 * 1024 }), // 1GiB limit
+    new FastifyAdapter({ bodyLimit: server.bodyLimit }),
   );
   app.enableVersioning({ type: VersioningType.URI });
   app.useBodyParser("application/octet-stream");


### PR DESCRIPTION
## Summary

- The Fastify `bodyLimit` is currently hardcoded to 1 GiB in `src/main.ts`. Turborepo cache artifacts that exceed that size are rejected with `ERROR [ExceptionsHandler] Request body is too large`, with no way to raise the ceiling short of forking/patching the image.
- This PR exposes the limit as an optional `BODY_LIMIT` environment variable (value in bytes). It is validated through the existing Zod schema in `src/config/configuration.ts` and defaults to `1073741824` (1 GiB), so out-of-the-box behavior is unchanged.
- `main.ts` now parses the configuration once before bootstrap and passes `server.bodyLimit` to `FastifyAdapter`, reusing the same `validate()` function that `ConfigModule` uses inside the app (so there is a single source of truth for env validation).

## Changes

- `src/config/configuration.ts` — add `BODY_LIMIT` to the schema, default `1 GiB`, enforce positive integer; surface it in the transformed config as `server.bodyLimit`.
- `src/main.ts` — read `server.bodyLimit` from validated config and pass to `FastifyAdapter`.
- `src/config/configuration.spec.ts` — extend existing transform assertions and add a `BODY_LIMIT` describe block covering default / custom / non-numeric / non-positive.
- `README.md` — document the new env var.

## Test plan

- [x] `pnpm test src/config/configuration.spec.ts` passes locally — covers default, custom value, and validation errors.
- [ ] `pnpm test` full unit suite green.
- [ ] `pnpm test:e2e` green (existing e2e uses `new FastifyAdapter()` with no bodyLimit and is unaffected).
- [ ] Integration tests (`compose-v1` / `compose-v2`) still green with defaults.
- [x] Manual: set `BODY_LIMIT=2147483648` and confirm a >1 GiB artifact `PUT` no longer returns "Request body is too large".

🤖 Generated with [Claude Code](https://claude.com/claude-code)